### PR TITLE
Freeze pip dependencies into requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+backports.functools-lru-cache==1.5
+bitstruct==3.7.0
+cycler==0.10.0
+h5py==2.7.1
+kiwisolver==1.0.1
+matplotlib==2.2.2
+numpy==1.14.2
+pandas==0.22.0
+pkg-resources==0.0.0
+pynmea2==1.12.0
+pyparsing==2.2.0
+python-dateutil==2.7.0
+pytz==2018.3
+six==1.11.0
+subprocess32==3.2.7


### PR DESCRIPTION
The dependencies weren't listed in a file so I did a `pip install` for each and froze the pip requirements. Hopefully it should make it a bit easier for others to use in future.

I'll write some readme notes about the requirements too (python 2.7 instead of python 3 for example) if you like.