### PR TITLE
Added 42000S to constants

### DIFF
--- a/readgssi/constants.py
+++ b/readgssi/constants.py
@@ -86,7 +86,8 @@ ANT = {
     '62300XT': 2300,
     '52600': 2600,
     '52600S': 2600,
-    'SSMINIXT': 2700
+    'SSMINIXT': 2700,
+    '42000S': 2000
 }
 
 # whether or not the file is GPS-enabled (does not guarantee presence of GPS data in file)


### PR DESCRIPTION
We are using the 42000S in our Setup so I added it to the constants. No clue if it's needed somewhere else though but the import reoutine reported not knowing the antenna